### PR TITLE
Fixed asset compile on Windows

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -234,6 +234,10 @@ func collectAssets(src string, extensions []string) ([]string, error) {
 		assets = append(assets, files...)
 	}
 
+	for idx := range assets {
+		assets[idx] = filepath.ToSlash(assets[idx])
+	}
+
 	return assets, nil
 
 }


### PR DESCRIPTION
Filepaths were receiving the Windows \ path separator which caused assets.json to believe there were escape sequences in the strings to be JSONified.